### PR TITLE
Fix issue #66 - Test discovery may fail if the test display name is longer than 447 characters.

### DIFF
--- a/xunit.runner.visualstudio.testadapter/Visitors/VsDiscoveryVisitor.cs
+++ b/xunit.runner.visualstudio.testadapter/Visitors/VsDiscoveryVisitor.cs
@@ -23,6 +23,8 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
     {
         static readonly Action<TestCase, string, string> addTraitThunk = GetAddTraitThunk();
         static readonly Uri uri = new Uri(Constants.ExecutorUri);
+		const string Ellipsis = "...";
+		const int MaximumDisplayNameLength = 447;
 
         readonly Func<bool> cancelThunk;
         readonly ITestFrameworkDiscoverer discoverer;
@@ -85,8 +87,15 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             if (value == null)
                 return String.Empty;
 
-            return value.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
+			return Truncate(value.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t"));
         }
+
+		static string Truncate(string value)
+		{
+			if (value.Length <= MaximumDisplayNameLength)
+				return value;
+			return value.Substring(0, MaximumDisplayNameLength - Ellipsis.Length) + Ellipsis;
+		}
 
         public int Finish()
         {


### PR DESCRIPTION
This pull request fixes issue #66 
The limit of 447 characters has been found by doing trial and error.