### PR TITLE
Dot net core

### DIFF
--- a/build/xunit.runner.visualstudio.dotnetcore.props
+++ b/build/xunit.runner.visualstudio.dotnetcore.props
@@ -1,8 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)xunit.runner.visualstudio.testadapter.dll">
-      <Link>xunit.runner.visualstudio.testadapter.dll</Link>
+    <Content Include="$(MSBuildThisFileDirectory)xunit.runner.visualstudio.dotnetcore.testadapter.dll">
+      <Link>xunit.runner.visualstudio.dotnetcore.testadapter.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)xunit.runner.utility.dotnet.dll">
+      <Link>xunit.runner.utility.dotnet.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>

--- a/visualstudio.xunit.proj
+++ b/visualstudio.xunit.proj
@@ -72,6 +72,7 @@
         Properties="Configuration=$(Configuration);TrackFileAccess=$(TrackFileAccess)"/>
     <Exec Command="dotnet restore -v Warning" />
     <Exec Command="dotnet build --configuration $(Configuration) xunit.runner.visualstudio.testadapter.dotnetcore\project.json"/>
+	<Exec Command="dotnet publish --configuration $(Configuration) xunit.runner.visualstudio.testadapter.dotnetcore\project.json"/>
   </Target>
 
   <Target Name="_Test">
@@ -148,7 +149,7 @@
 
               Log.LogMessage("Downloading latest version of NuGet.exe...");
               WebClient webClient = new WebClient();
-              webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", OutputFilename);
+              webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/v3.5.0-rc1/NuGet.exe", OutputFilename);
 
               return true;
           }

--- a/xunit.runner.visualstudio.nuspec
+++ b/xunit.runner.visualstudio.nuspec
@@ -22,10 +22,10 @@
     <dependencies>
       <group targetFramework="netcoreapp1.0">
         <dependency id="Microsoft.Extensions.DependencyModel" version="1.0.0" />
-        <dependency id="MSTest.ObjectModel" version="1.0.1-preview" />
+        <dependency id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" />
         <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="System.Threading.ThreadPool" version="4.0.10" />
-        <dependency id="xunit.runner.utility" version="2.2.0-beta3-build3335" />
+        <dependency id="xunit.runner.utility" version="2.2.0-beta3-build3401" />
       </group>
     </dependencies>
   </metadata>

--- a/xunit.runner.visualstudio.nuspec
+++ b/xunit.runner.visualstudio.nuspec
@@ -53,6 +53,6 @@
     <file src="xunit.runner.visualstudio.wpa81\bin\Release\xunit.runner.visualstudio.wpa81.pri" target="build\wpa81\" />
 
     <file src="build\xunit.runner.visualstudio.dotnetcore.props"                                                                     target="build\netcoreapp1.0\xunit.runner.visualstudio.props" />
-    <file src="xunit.runner.visualstudio.testadapter.dotnetcore\bin\Release\netcoreapp1.0\xunit.runner.visualstudio.testadapter.dll" target="build\netcoreapp1.0\" />
+    <file src="xunit.runner.visualstudio.testadapter.dotnetcore\bin\Release\netcoreapp1.0\xunit.runner.visualstudio.dotnetcore.testadapter.dll" target="build\netcoreapp1.0\" />
   </files>
 </package>

--- a/xunit.runner.visualstudio.nuspec
+++ b/xunit.runner.visualstudio.nuspec
@@ -25,7 +25,6 @@
         <dependency id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" />
         <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="System.Threading.ThreadPool" version="4.0.10" />
-        <dependency id="xunit.runner.utility" version="2.2.0-beta3-build3401" />
       </group>
     </dependencies>
   </metadata>
@@ -53,6 +52,7 @@
     <file src="xunit.runner.visualstudio.wpa81\bin\Release\xunit.runner.visualstudio.wpa81.pri" target="build\wpa81\" />
 
     <file src="build\xunit.runner.visualstudio.dotnetcore.props"                                                                     target="build\netcoreapp1.0\xunit.runner.visualstudio.props" />
-    <file src="xunit.runner.visualstudio.testadapter.dotnetcore\bin\Release\netcoreapp1.0\xunit.runner.visualstudio.dotnetcore.testadapter.dll" target="build\netcoreapp1.0\" />
+    <file src="xunit.runner.visualstudio.testadapter.dotnetcore\bin\Release\netcoreapp1.0\publish\xunit.runner.visualstudio.dotnetcore.testadapter.dll" target="build\netcoreapp1.0\" />
+    <file src="xunit.runner.visualstudio.testadapter.dotnetcore\bin\Release\netcoreapp1.0\publish\xunit.runner.utility.dotnet.dll" target="build\netcoreapp1.0\" />
   </files>
 </package>

--- a/xunit.runner.visualstudio.testadapter.dotnetcore/project.json
+++ b/xunit.runner.visualstudio.testadapter.dotnetcore/project.json
@@ -32,7 +32,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.Extensions.DependencyModel": "1.0.0",
+    "Microsoft.Extensions.DependencyModel": "1.0.0-rc2-002702",
     "Microsoft.TestPlatform.ObjectModel": "11.0.0",
     "NETStandard.Library": "1.6.0",
     "System.Threading.ThreadPool": "4.0.10",

--- a/xunit.runner.visualstudio.testadapter.dotnetcore/project.json
+++ b/xunit.runner.visualstudio.testadapter.dotnetcore/project.json
@@ -32,8 +32,8 @@
     }
   },
   "dependencies": {
-    "Microsoft.Extensions.DependencyModel": "1.0.0-rc2-002702",
-    "MSTest.ObjectModel": "1.0.1-preview",
+    "Microsoft.Extensions.DependencyModel": "1.0.0",
+    "Microsoft.TestPlatform.ObjectModel": "11.0.0",
     "NETStandard.Library": "1.6.0",
     "System.Threading.ThreadPool": "4.0.10",
     "xunit.runner.utility": "2.2.0-beta3-build3401"

--- a/xunit.runner.visualstudio.testadapter.dotnetcore/project.json
+++ b/xunit.runner.visualstudio.testadapter.dotnetcore/project.json
@@ -32,9 +32,12 @@
     }
   },
   "dependencies": {
-    "Microsoft.Extensions.DependencyModel": "1.0.0-rc2-002702",
+    "Microsoft.Extensions.DependencyModel": "1.0.0",
     "Microsoft.TestPlatform.ObjectModel": "11.0.0",
-    "NETStandard.Library": "1.6.0",
+    "Microsoft.NETCore.App": {
+      "version": "1.0.0",
+      "type": "platform"
+    },
     "System.Threading.ThreadPool": "4.0.10",
     "xunit.runner.utility": "2.2.0-beta3-build3401"
   }

--- a/xunit.runner.visualstudio.testadapter.dotnetcore/project.json
+++ b/xunit.runner.visualstudio.testadapter.dotnetcore/project.json
@@ -19,7 +19,7 @@
       "../xunit.runner.visualstudio.testadapter/VsTestRunner.cs",
       "../common/GlobalAssemblyInfo.cs"
     ],
-    "outputName": "xunit.runner.visualstudio.testadapter",
+    "outputName": "xunit.runner.visualstudio.dotnetcore.testadapter",
     "warningsAsErrors": true
   },
   "frameworks": {

--- a/xunit.runner.visualstudio.testadapter/VsTestRunner.cs
+++ b/xunit.runner.visualstudio.testadapter/VsTestRunner.cs
@@ -331,7 +331,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
                 using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(File.ReadAllText(depsFile))))
                 {
                     var context = new DependencyContextJsonReader().Read(stream);
-                    var xunitLibrary = context.CompileLibraries.Where(lib => lib.Name.Equals("xunit")).FirstOrDefault();
+                    var xunitLibrary = context.RuntimeLibraries.Where(lib => lib.Name.Equals("xunit")).FirstOrDefault();
                     return xunitLibrary != null;
                 }
             }


### PR DESCRIPTION
1. Updated ObjectModel package.
2. Updated check for xunitlibrary in RuntimeLibraries in deps file.
3. Renamed xunit's dotnet test adapter dll name.
