### PR TITLE
Decouple Runner Utility from package

### DIFF
--- a/build/xunit.runner.visualstudio.desktop.props
+++ b/build/xunit.runner.visualstudio.desktop.props
@@ -11,7 +11,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\_common\xunit.runner.reporters.desktop.dll">
+    <Content Include="$(MSBuildThisFileDirectory)..\_common\xunit.runner.reporters.desktop.dll"
+             Condition=" '$(TargetFrameworkVersion)' != 'v2.0' and '$(TargetFrameworkVersion)' != 'v3.0' and '$(TargetFrameworkVersion)' != 'v3.5' " 
+             >
       <Link>xunit.runner.reporters.desktop.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/build/xunit.runner.visualstudio.desktop.props
+++ b/build/xunit.runner.visualstudio.desktop.props
@@ -11,6 +11,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\_common\xunit.runner.reporters.desktop.dll">
+      <Link>xunit.runner.reporters.desktop.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
     <Content Include="$(MSBuildThisFileDirectory)..\_common\xunit.abstractions.dll">
       <Link>xunit.abstractions.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/build/xunit.runner.visualstudio.dotnetcore.props
+++ b/build/xunit.runner.visualstudio.dotnetcore.props
@@ -11,5 +11,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)xunit.runner.reporters.dotnet.dll">
+      <Link>xunit.runner.reporters.dotnet.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
   </ItemGroup>
 </Project>

--- a/test.harness/packages.config
+++ b/test.harness/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.2.0-beta4-build3466" targetFramework="net45" />
+  <package id="xunit" version="2.2.0-beta4-build3468" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net45" />
-  <package id="xunit.assert" version="2.2.0-beta4-build3466" targetFramework="net45" />
-  <package id="xunit.core" version="2.2.0-beta4-build3466" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.2.0-beta4-build3466" targetFramework="net45" />
-  <package id="xunit.extensibility.execution" version="2.2.0-beta4-build3466" targetFramework="net45" />
+  <package id="xunit.assert" version="2.2.0-beta4-build3468" targetFramework="net45" />
+  <package id="xunit.core" version="2.2.0-beta4-build3468" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.2.0-beta4-build3468" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.2.0-beta4-build3468" targetFramework="net45" />
 </packages>

--- a/test.harness/test.harness.csproj
+++ b/test.harness/test.harness.csproj
@@ -45,16 +45,16 @@
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.2.0.3466, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.assert.2.2.0-beta4-build3466\lib\netstandard1.0\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.2.0.3468, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.2.0-beta4-build3468\lib\netstandard1.0\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.2.0.3466, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.2.0-beta4-build3466\lib\net45\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.2.0.3468, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.2.0-beta4-build3468\lib\net45\xunit.core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.2.0.3466, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.execution.2.2.0-beta4-build3466\lib\net45\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3468, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.2.0-beta4-build3468\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/test.xunit.runner.visualstudio.desktop/packages.config
+++ b/test.xunit.runner.visualstudio.desktop/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="Microsoft.VisualStudio.TestPlatform.ObjectModel" version="0.0.6" targetFramework="net45" />
   <package id="NSubstitute" version="1.8.2.0" targetFramework="net46" />
-  <package id="xunit" version="2.2.0-beta4-build3466" targetFramework="net45" />
+  <package id="xunit" version="2.2.0-beta4-build3468" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net45" />
-  <package id="xunit.assert" version="2.2.0-beta4-build3466" targetFramework="net45" />
-  <package id="xunit.core" version="2.2.0-beta4-build3466" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.2.0-beta4-build3466" targetFramework="net45" />
-  <package id="xunit.extensibility.execution" version="2.2.0-beta4-build3466" targetFramework="net45" />
+  <package id="xunit.assert" version="2.2.0-beta4-build3468" targetFramework="net45" />
+  <package id="xunit.core" version="2.2.0-beta4-build3468" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.2.0-beta4-build3468" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.2.0-beta4-build3468" targetFramework="net45" />
 </packages>

--- a/test.xunit.runner.visualstudio.desktop/test.xunit.runner.visualstudio.desktop.csproj
+++ b/test.xunit.runner.visualstudio.desktop/test.xunit.runner.visualstudio.desktop.csproj
@@ -52,16 +52,16 @@
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.2.0.3466, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.assert.2.2.0-beta4-build3466\lib\netstandard1.0\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.2.0.3468, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.2.0-beta4-build3468\lib\netstandard1.0\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.2.0.3466, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.2.0-beta4-build3466\lib\net45\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.2.0.3468, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.2.0-beta4-build3468\lib\net45\xunit.core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.2.0.3466, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.execution.2.2.0-beta4-build3466\lib\net45\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3468, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.2.0-beta4-build3468\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/visualstudio.xunit.proj
+++ b/visualstudio.xunit.proj
@@ -47,6 +47,7 @@
     <Message Text="Restoring NuGet packages..." Importance="High" />
     <Exec Command="&quot;$(NuGetExePath)&quot; install xunit.buildtasks -Source @(PackageSource) -SolutionDir &quot;$(SolutionDir)&quot; -Verbosity quiet -ExcludeVersion" Condition="!Exists('$(SolutionDir)\packages\xunit.buildtasks\')" />
     <Exec Command="&quot;$(NuGetExePath)&quot; install xunit.runner.console -Source @(PackageSource) -SolutionDir &quot;$(SolutionDir)&quot; -Verbosity quiet -ExcludeVersion" Condition="!Exists('$(SolutionDir)\packages\xunit.runner.console\')" />
+    <Exec Command="&quot;$(NuGetExePath)&quot; install xunit.runner.reporters -Source @(PackageSource) -SolutionDir &quot;$(SolutionDir)&quot; -Verbosity quiet -ExcludeVersion -Pre" Condition="!Exists('$(SolutionDir)\packages\xunit.runner.reporters\')" />
     <Exec Command="&quot;$(NuGetExePath)&quot; install gitlink -SolutionDir &quot;$(SolutionDir)&quot; -Verbosity quiet -ExcludeVersion" Condition="!Exists('$(SolutionDir)\packages\gitlink\')" />
     <Exec Command="&quot;$(NuGetExePath)&quot; restore &quot;$(SolutionDir)\visualstudio.xunit.sln&quot; -NonInteractive -Source @(PackageSource) -Verbosity quiet $(NuGetNoCache)" />
   </Target>

--- a/visualstudio.xunit.sln
+++ b/visualstudio.xunit.sln
@@ -10,6 +10,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.runner.visualstudio.d
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4E13DEEC-B4B3-4D16-8D20-21FE543916B0}"
 	ProjectSection(SolutionItems) = preProject
+		visualstudio.xunit.proj = visualstudio.xunit.proj
 		build\xunit.runner.visualstudio.desktop.props = build\xunit.runner.visualstudio.desktop.props
 		build\xunit.runner.visualstudio.dotnetcore.props = build\xunit.runner.visualstudio.dotnetcore.props
 		xunit.runner.visualstudio.nuspec = xunit.runner.visualstudio.nuspec

--- a/xunit.runner.visualstudio.desktop/VsTestRunner.cs
+++ b/xunit.runner.visualstudio.desktop/VsTestRunner.cs
@@ -389,7 +389,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
                 var parallelizeAssemblies = !RunSettingsHelper.DisableParallelization && assemblies.All(runInfo => runInfo.Configuration.ParallelizeAssemblyOrDefault);
 
 
-                var reporterMessageHandler = MessageSinkWithTypesAdapter.Wrap( GetRunnerReporter(assemblies.Select(ari => ari.AssemblyFileName))
+                var reporterMessageHandler = MessageSinkWithTypesAdapter.Wrap(GetRunnerReporter(assemblies.Select(ari => ari.AssemblyFileName))
                                                 .CreateMessageHandler(new VisualStudioRunnerLogger(logger)));
 
 
@@ -539,9 +539,25 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
                         .Select(dcjr.Read);
             var ctx = deps.Aggregate(DependencyContext.Default, (context, dependencyContext) => context.Merge(dependencyContext));
             dcjr.Dispose();
+
+
+            var depsAssms = ctx.GetRuntimeAssemblyNames(RuntimeEnvironment.GetRuntimeIdentifier())
+                               .ToList();
+
+            // Make sure to also check assemblies within the directory of the sources
+            var dllsInSources = sources
+                        .Select(Path.GetFullPath)
+                        .Select(Path.GetDirectoryName)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .SelectMany(p => Directory.GetFiles(p, "*.dll").Select(f => Path.Combine(p, f)))
+                        .Select(f => new AssemblyName { Name = Path.GetFileNameWithoutExtension(f) })
+                        .ToList();
+
+                    
             
-            
-            foreach (var assemblyName in ctx.GetRuntimeAssemblyNames(RuntimeEnvironment.GetRuntimeIdentifier()))
+
+
+            foreach (var assemblyName in depsAssms.Concat(dllsInSources))
             {
                 try
                 {

--- a/xunit.runner.visualstudio.desktop/VsTestRunner.cs
+++ b/xunit.runner.visualstudio.desktop/VsTestRunner.cs
@@ -540,7 +540,6 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             var ctx = deps.Aggregate(DependencyContext.Default, (context, dependencyContext) => context.Merge(dependencyContext));
             dcjr.Dispose();
 
-
             var depsAssms = ctx.GetRuntimeAssemblyNames(RuntimeEnvironment.GetRuntimeIdentifier())
                                .ToList();
 
@@ -552,10 +551,6 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
                         .SelectMany(p => Directory.GetFiles(p, "*.dll").Select(f => Path.Combine(p, f)))
                         .Select(f => new AssemblyName { Name = Path.GetFileNameWithoutExtension(f) })
                         .ToList();
-
-                    
-            
-
 
             foreach (var assemblyName in depsAssms.Concat(dllsInSources))
             {

--- a/xunit.runner.visualstudio.desktop/packages.config
+++ b/xunit.runner.visualstudio.desktop/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" targetFramework="net35" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net35" />
-  <package id="xunit.runner.utility" version="2.2.0-beta4-build3466" targetFramework="net35" />
+  <package id="xunit.runner.utility" version="2.2.0-beta4-build3468" targetFramework="net35" />
 </packages>

--- a/xunit.runner.visualstudio.desktop/xunit.runner.visualstudio.desktop.csproj
+++ b/xunit.runner.visualstudio.desktop/xunit.runner.visualstudio.desktop.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.runner.utility.desktop, Version=2.2.0.3466, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.runner.utility.2.2.0-beta4-build3466\lib\net35\xunit.runner.utility.desktop.dll</HintPath>
+    <Reference Include="xunit.runner.utility.desktop, Version=2.2.0.3468, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.runner.utility.2.2.0-beta4-build3468\lib\net35\xunit.runner.utility.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/xunit.runner.visualstudio.dotnetcore/project.json
+++ b/xunit.runner.visualstudio.dotnetcore/project.json
@@ -40,7 +40,6 @@
       "type": "platform"
     },
     "System.Threading.ThreadPool": "4.0.10",
-    "xunit.runner.reporters": "2.2.0-beta4-build3466",
-    "xunit.runner.utility": "2.2.0-beta4-build3466"
-  }
+    "xunit.runner.reporters": "2.2.0-beta4-build3468",
+    "xunit.runner.utility": "2.2.0-beta4-build3468"  }
 }

--- a/xunit.runner.visualstudio.dotnetcore/project.json
+++ b/xunit.runner.visualstudio.dotnetcore/project.json
@@ -40,6 +40,7 @@
       "type": "platform"
     },
     "System.Threading.ThreadPool": "4.0.10",
-    "xunit.runner.reporters": "2.2.0-beta4-build3468",
-    "xunit.runner.utility": "2.2.0-beta4-build3468"  }
+    "xunit.runner.utility": "2.2.0-beta4-build3468",
+    "xunit.runner.reporters": "2.2.0-beta4-build3468"  
+  }
 }

--- a/xunit.runner.visualstudio.nuspec
+++ b/xunit.runner.visualstudio.nuspec
@@ -29,7 +29,7 @@ Supported platforms:
   <files>
     <file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.abstractions.dll"                    target="build\_common\" />
     <file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.runner.utility.desktop.dll"          target="build\_common\" />
-    <!--<file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.runner.reporters.desktop.dll"        target="build\_common\" />-->
+    <file src="packages\xunit.runner.reporters\lib\net45\xunit.runner.reporters.desktop.dll"            target="build\_common\" />
     <file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.runner.visualstudio.testadapter.dll" target="build\_common\" />
 
     <file src="build\xunit.runner.visualstudio.desktop.props" target="build\net20\xunit.runner.visualstudio.props" />

--- a/xunit.runner.visualstudio.nuspec
+++ b/xunit.runner.visualstudio.nuspec
@@ -23,16 +23,13 @@ Supported platforms:
         <dependency id="Microsoft.TestPlatform.ObjectModel" version="11.0.0" />
         <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="System.Threading.ThreadPool" version="4.0.10" />
-        <dependency id="xunit.runner.reporters" version="2.2.0-beta4-build3466" />
-      </group>
-      <group targetFramework="net45">
-        <dependency id="xunit.runner.reporters" version="2.2.0-beta4-build3466" />
       </group>
     </dependencies>
   </metadata>
   <files>
     <file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.abstractions.dll"                    target="build\_common\" />
     <file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.runner.utility.desktop.dll"          target="build\_common\" />
+    <file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.runner.reporters.desktop.dll"        target="build\_common\" />
     <file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.runner.visualstudio.testadapter.dll" target="build\_common\" />
 
     <file src="build\xunit.runner.visualstudio.desktop.props" target="build\net20\xunit.runner.visualstudio.props" />
@@ -45,5 +42,6 @@ Supported platforms:
     <file src="build\xunit.runner.visualstudio.dotnetcore.props"                                                                            target="build\netcoreapp1.0\xunit.runner.visualstudio.props" />
     <file src="xunit.runner.visualstudio.dotnetcore\bin\Release\netcoreapp1.0\publish\xunit.runner.visualstudio.dotnetcore.testadapter.dll" target="build\netcoreapp1.0\" />
     <file src="xunit.runner.visualstudio.dotnetcore\bin\Release\netcoreapp1.0\publish\xunit.runner.utility.dotnet.dll"                      target="build\netcoreapp1.0\" />
+    <file src="xunit.runner.visualstudio.dotnetcore\bin\Release\netcoreapp1.0\publish\xunit.runner.reporters.dotnet.dll"                    target="build\netcoreapp1.0\" />
   </files>
 </package>

--- a/xunit.runner.visualstudio.nuspec
+++ b/xunit.runner.visualstudio.nuspec
@@ -29,7 +29,7 @@ Supported platforms:
   <files>
     <file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.abstractions.dll"                    target="build\_common\" />
     <file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.runner.utility.desktop.dll"          target="build\_common\" />
-    <file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.runner.reporters.desktop.dll"        target="build\_common\" />
+    <!--<file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.runner.reporters.desktop.dll"        target="build\_common\" />-->
     <file src="xunit.runner.visualstudio.desktop\bin\Release\xunit.runner.visualstudio.testadapter.dll" target="build\_common\" />
 
     <file src="build\xunit.runner.visualstudio.desktop.props" target="build\net20\xunit.runner.visualstudio.props" />

--- a/xunit.runner.visualstudio.uwp/project.json
+++ b/xunit.runner.visualstudio.uwp/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
     "Microsoft.VisualStudio.TestPlatform.ObjectModel": "0.0.6",
-    "xunit.runner.utility": "2.2.0-beta4-build3466"
+    "xunit.runner.utility": "2.2.0-beta4-build3468"
   },
   "frameworks": {
     "uap10.0": {}


### PR DESCRIPTION
This PR removes the direct dependency on the Reporters from the adapter, thereby breaking the transitive ref to the utility lib.

Instead, it packages up a copy of the reporter at package build time and copies to the output dir like it currently does for utility.

One todo: need to determine how to download the net45 version of the reporter lib for packaging in the nuspec for use with the net35 adapter. Unlike the netcoreapp1.0 version, we can't install it as a local dependency since the package won't install.

For the netcoreapp version, I've tested the logic in the debugger and verified the files are enumerated and loaded.

AppVeyor sees the tests (proving the reporter is working) with a copy built from this branch:
https://ci.appveyor.com/project/onovotny/xunittestproject1-test/build/1.0.17/tests