### PR TITLE
Fix Issue #746 by gathering all trait names before filtering when running tests

### DIFF
--- a/test.harness/readme.txt
+++ b/test.harness/readme.txt
@@ -5,7 +5,7 @@ Set your working directory to your output dir:
 c:\dev\xunit.vsrunner\test.harness\bin\Debug\
 
 Set the command line args to
-test.harness.dll /testadapterpath:C:\dev\xunit.vsrunner\xunit.runner.visualstudio.testadapter\bin\Debug
+test.harness.dll test.testcasefilter.dll /TestCaseFilter:"FilterCategory!=Exclude" /testadapterpath:C:\dev\xunit.vsrunner\xunit.runner.visualstudio.testadapter\bin\Debug
 
 You'll need to enable native debugging and enable the child process debugger. To enable the child process debugger,
 install the following extension:

--- a/test.harness/test.harness.csproj
+++ b/test.harness/test.harness.csproj
@@ -69,13 +69,19 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\test.testcasefilter\test.testcasefilter.csproj">
+      <Project>{e31c01f0-1c54-4c26-8c4c-3ee31dfd03ea}</Project>
+      <Name>test.testcasefilter</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <!-- Common debugging support -->
     <StartAction>Program</StartAction>
     <StartProgram>$(DevEnvDir)CommonExtensions\Microsoft\TestWindow\vstest.console.exe</StartProgram>
     <StartWorkingDirectory>$(TargetDir)</StartWorkingDirectory>
-    <StartArguments>test.harness.dll /testadapterpath:$(SolutionDir)xunit.runner.visualstudio.desktop\bin\$(Configuration)</StartArguments>
+    <StartArguments>test.harness.dll test.testcasefilter.dll /TestCaseFilter:"FilterCategory!=Exclude" /testadapterpath:$(SolutionDir)xunit.runner.visualstudio.desktop\bin\$(Configuration)</StartArguments>
     <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test.testcasefilter/Class1.cs
+++ b/test.testcasefilter/Class1.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace test.testcasefilter
+{
+    public class Tests
+    {
+        [Fact]
+        [Trait("FilterCategory", "Exclude")]
+        public void TestWithTraitToFilterOn()
+        {
+            Assert.True(true);
+        }
+    }
+}

--- a/test.testcasefilter/Properties/AssemblyInfo.cs
+++ b/test.testcasefilter/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("test.testcasefilter")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("test.testcasefilter")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e31c01f0-1c54-4c26-8c4c-3ee31dfd03ea")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test.testcasefilter/packages.config
+++ b/test.testcasefilter/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.2.0-beta5-build3474" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net45" />
+  <package id="xunit.assert" version="2.2.0-beta5-build3474" targetFramework="net45" />
+  <package id="xunit.core" version="2.2.0-beta5-build3474" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.2.0-beta5-build3474" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.2.0-beta5-build3474" targetFramework="net45" />
+</packages>

--- a/test.testcasefilter/readme.txt
+++ b/test.testcasefilter/readme.txt
@@ -1,0 +1,4 @@
+﻿To use this, see readme.txt in the test.harness project
+
+This project provides a second assembly containing a fact with a trait to allow the test harness to be run with
+various combinations and orderings of assemblies while using the using /TestCaseFilter option of vstest.console.exe.

--- a/test.testcasefilter/test.testcasefilter.csproj
+++ b/test.testcasefilter/test.testcasefilter.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{276BA4CF-B023-4159-85E8-B5A9A4D4493A}</ProjectGuid>
+    <ProjectGuid>{E31C01F0-1C54-4C26-8C4C-3EE31DFD03EA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>test.xunit.runner.visualstudio.testadapter</RootNamespace>
-    <AssemblyName>test.xunit.runner.visualstudio.desktop</AssemblyName>
+    <RootNamespace>test.testcasefilter</RootNamespace>
+    <AssemblyName>test.testcasefilter</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -31,13 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
-      <HintPath>..\packages\Microsoft.VisualStudio.TestPlatform.ObjectModel.0.0.6\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
-    </Reference>
-    <Reference Include="NSubstitute, Version=1.8.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\NSubstitute.1.8.2.0\lib\net45\NSubstitute.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -64,20 +57,14 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="RunSettingsHelperTests.cs" />
-    <Compile Include="TestCaseFilterTests.cs" />
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\xunit.runner.visualstudio.desktop\xunit.runner.visualstudio.desktop.csproj">
-      <Project>{ebab9937-2a6a-41ea-848b-3f7ede2396cb}</Project>
-      <Name>xunit.runner.visualstudio.testadapter</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
+    <Content Include="readme.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/visualstudio.xunit.sln
+++ b/visualstudio.xunit.sln
@@ -30,6 +30,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.runner.visualstudio.u
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "xunit.runner.visualstudio.dotnetcore", "xunit.runner.visualstudio.dotnetcore\xunit.runner.visualstudio.dotnetcore.xproj", "{92844AB6-B80A-4C62-8CA0-ED8FD128D99C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test.testcasefilter", "test.testcasefilter\test.testcasefilter.csproj", "{E31C01F0-1C54-4C26-8C4C-3EE31DFD03EA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{92844AB6-B80A-4C62-8CA0-ED8FD128D99C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{92844AB6-B80A-4C62-8CA0-ED8FD128D99C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{92844AB6-B80A-4C62-8CA0-ED8FD128D99C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E31C01F0-1C54-4C26-8C4C-3EE31DFD03EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E31C01F0-1C54-4C26-8C4C-3EE31DFD03EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E31C01F0-1C54-4C26-8C4C-3EE31DFD03EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E31C01F0-1C54-4C26-8C4C-3EE31DFD03EA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,5 +72,6 @@ Global
 		{276BA4CF-B023-4159-85E8-B5A9A4D4493A} = {88AA0DC3-2723-4E7D-A89E-A977F319B3AA}
 		{9220495E-D0C7-4F0D-B963-A5E17FF63386} = {BA799592-92C2-40AD-9FB2-623E94A427F3}
 		{92844AB6-B80A-4C62-8CA0-ED8FD128D99C} = {BA799592-92C2-40AD-9FB2-623E94A427F3}
+		{E31C01F0-1C54-4C26-8C4C-3EE31DFD03EA} = {88AA0DC3-2723-4E7D-A89E-A977F319B3AA}
 	EndGlobalSection
 EndGlobal

--- a/xunit.runner.visualstudio.desktop/xunit.runner.visualstudio.desktop.csproj
+++ b/xunit.runner.visualstudio.desktop/xunit.runner.visualstudio.desktop.csproj
@@ -69,7 +69,7 @@
     </Compile>
     <Compile Include="Utility\RunSettingsHelper.cs" />
     <Compile Include="Utility\VisualStudioRunnerLogger.cs" />
-    <Compile Include="Utility\TestCaseFilterHelper.cs" />
+    <Compile Include="Utility\TestCaseFilter.cs" />
     <Compile Include="Utility\AssemblyExtensions.cs" />
     <Compile Include="Utility\AssemblyRunInfo.cs" />
     <Compile Include="Utility\ExceptionExtensions.cs" />

--- a/xunit.runner.visualstudio.dotnetcore/project.json
+++ b/xunit.runner.visualstudio.dotnetcore/project.json
@@ -13,7 +13,7 @@
       "../xunit.runner.visualstudio.desktop/Utility/Guard.cs",
       "../xunit.runner.visualstudio.desktop/Utility/LoggerHelper.cs",
       "../xunit.runner.visualstudio.desktop/Utility/RunSettingsHelper.cs",
-      "../xunit.runner.visualstudio.desktop/Utility/TestCaseFilterHelper.cs",
+      "../xunit.runner.visualstudio.desktop/Utility/TestCaseFilter.cs",
       "../xunit.runner.visualstudio.desktop/Utility/VisualStudioRunnerLogger.cs",
       "../xunit.runner.visualstudio.desktop/Constants.cs",
       "../xunit.runner.visualstudio.desktop/VsTestRunner.cs",

--- a/xunit.runner.visualstudio.uwp/xunit.runner.visualstudio.uwp.csproj
+++ b/xunit.runner.visualstudio.uwp/xunit.runner.visualstudio.uwp.csproj
@@ -87,8 +87,8 @@
     <Compile Include="..\xunit.runner.visualstudio.desktop\Utility\RunSettingsHelper.cs">
       <Link>Utility\RunSettingsHelper.cs</Link>
     </Compile>
-    <Compile Include="..\xunit.runner.visualstudio.desktop\Utility\TestCaseFilterHelper.cs">
-      <Link>Utility\TestCaseFilterHelper.cs</Link>
+    <Compile Include="..\xunit.runner.visualstudio.desktop\Utility\TestCaseFilter.cs">
+      <Link>Utility\TestCaseFilter.cs</Link>
     </Compile>
     <Compile Include="..\xunit.runner.visualstudio.desktop\Utility\VisualStudioRunnerLogger.cs">
       <Link>Utility\VisualStudioRunnerLogger.cs</Link>


### PR DESCRIPTION
Fixes [#746](https://github.com/xunit/xunit/issues/746) and related issues by re-working discovery on run to first gather info on all test cases so all valid trait names are known, and only then try to apply filtering.

Verified on desktop by using the included modifications to the test harness.

Sharing for feedback but I'd be happy to do some further cleanup / get more of this under unit tests. I did modify the test harness to reproduce the issue but I'm not sure the additional complexity is worth it going forward.