### PR TITLE
Fix #863 vstest.console doesn't discover tests in UWP appx

### DIFF
--- a/xunit.runner.visualstudio.desktop/VsTestRunner.cs
+++ b/xunit.runner.visualstudio.desktop/VsTestRunner.cs
@@ -111,6 +111,9 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
                 sources = Directory.GetFiles(sourcePath, "*.dll")
                                    .Where(file => !platformAssemblies.Contains(Path.GetFileName(file)))
                                    .ToList();
+
+                ((List<string>)sources).AddRange(Directory.GetFiles(sourcePath, "*.exe")
+                                   .Where(file => !platformAssemblies.Contains(Path.GetFileName(file))));
             }
 
             RunTests(runContext, frameworkHandle, logger, () => GetTests(sources, logger, runContext));


### PR DESCRIPTION
When vstest.console.exe is run against an appx file (e.g. vstest.console.exe MyApp.appx), vstest.console.exe deploys the appx, then runs the app in a AppContainer.  vstest.console.exe finds the xunit uwp runner, which is packaged inside the appx.  vstest.console.exe passes the path to the appx file to the xunit runner. 

The xunit runner gets a list of dlls files in the appx installed location and performs test discover on them.  Tests in a UWP unit test aren't detected by this process because they are in an exe file.

This change expands the list of files to perform test discover on to include exe files.

Note that in order for vstest.console.exe to execute tests, the TestAdapterPath switch must not be supplied, so that vstest.console picks up the uwp runner that is packaged in the appx file, and not the desktop runner.