### PR TITLE
Add support for DesignMode.

### DIFF
--- a/test.xunit.runner.visualstudio.desktop/RunSettingsHelperTests.cs
+++ b/test.xunit.runner.visualstudio.desktop/RunSettingsHelperTests.cs
@@ -26,6 +26,7 @@ public class RunSettingsHelperTests
                     <RunConfiguration>
                         <DisableAppDomain>1234</DisableAppDomain>
                         <DisableParallelization>smfhekhgekr</DisableParallelization>
+                        <DesignMode>3245sax</DesignMode>
                     </RunConfiguration>
                 </RunSettings>";
 
@@ -55,8 +56,9 @@ public class RunSettingsHelperTests
 
         // Attribute must be ignored
         Assert.True(RunSettingsHelper.DisableAppDomain);
-        // Default value must be used for disableparallelization
+        // Default value must be used for disableparallelization, designmode
         Assert.False(RunSettingsHelper.DisableParallelization);
+        Assert.True(RunSettingsHelper.DesignMode);
     }
 
     [Fact]
@@ -73,8 +75,9 @@ public class RunSettingsHelperTests
 
         RunSettingsHelper.ReadRunSettings(settingsXml);
 
-        // Default value must be used for DisableAppDomain
+        // Default value must be used for DisableAppDomain, DesignMode
         Assert.False(RunSettingsHelper.DisableAppDomain);
+        Assert.True(RunSettingsHelper.DesignMode);
         // DisableParallelization can be set
         Assert.True(RunSettingsHelper.DisableParallelization);
     }
@@ -97,9 +100,33 @@ public class RunSettingsHelperTests
 
         RunSettingsHelper.ReadRunSettings(settingsXml);
 
-        // Correct values must be sets
+        // Correct values must be set
         Assert.Equal(disableAppDomain, RunSettingsHelper.DisableAppDomain);
         Assert.Equal(disableParallelization, RunSettingsHelper.DisableParallelization);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RunSettingsHelperShouldReadDesignModeSettingCorrectly(bool designMode)
+    {
+        string settingsXml =
+            $@"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                    <RunConfiguration>
+                        <DisableAppDomain>true</DisableAppDomain>
+                        <DisableParallelization>invalid</DisableParallelization>
+                        <DesignMode>{designMode.ToString().ToLowerInvariant()}</DesignMode>
+                    </RunConfiguration>
+                </RunSettings>";
+
+        RunSettingsHelper.ReadRunSettings(settingsXml);
+
+        // Correct values must be set
+        Assert.Equal(designMode, RunSettingsHelper.DesignMode);
+        Assert.True(RunSettingsHelper.DisableAppDomain);
+        // Default value should be set for DisableParallelization
+        Assert.False(RunSettingsHelper.DisableParallelization);
     }
 
     [Fact]

--- a/xunit.runner.visualstudio.desktop/Sinks/VsExecutionSink.cs
+++ b/xunit.runner.visualstudio.desktop/Sinks/VsExecutionSink.cs
@@ -305,7 +305,6 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
         {
             var result = innerSink.OnMessageWithTypes(message, messageTypes);
             return base.OnMessageWithTypes(message, messageTypes) && result;
-
         }
     }
 }

--- a/xunit.runner.visualstudio.desktop/Utility/RunSettingsHelper.cs
+++ b/xunit.runner.visualstudio.desktop/Utility/RunSettingsHelper.cs
@@ -9,6 +9,12 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
         public static bool DisableAppDomain { get; private set; }
 
         public static bool DisableParallelization { get; private set; }
+
+        /// <summary>
+        /// Design mode indicates the context of a test run. True indicates the test run is invoked from an editor
+        /// or IDE.
+        /// </summary>
+        public static bool DesignMode { get; private set; }
 /*
         public static bool NoAutoReporters { get; private set; }
         public static string ReporterSwitch { get; private set; }
@@ -22,6 +28,10 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             // reset first, do not want to propagate earlier settings in cases where execution host is kept alive
             DisableAppDomain = false;
             DisableParallelization = false;
+
+            // We're keeping the default value as true since the adapter (prior to VS 2017) shouldn't
+            // differentiate between VS or vstest.console.
+            DesignMode = true;
             //NoAutoReporters = false;
 
 
@@ -42,6 +52,12 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
                         bool disableParallelization;
                         if (bool.TryParse(disableParallelizationString, out disableParallelization))
                             DisableParallelization = disableParallelization;
+
+                        // It is set to True if test is running from an Editor/IDE context.
+                        var designModeString = element.Element("DesignMode")?.Value;
+                        bool designMode;
+                        if (bool.TryParse(designModeString, out designMode))
+                            DesignMode = designMode;
 /*
                         var noAutoReportersString = element.Element("NoAutoReporters")?.Value;
                         bool noAutoReporters;


### PR DESCRIPTION
Turn off Source Information query when design mode is false (command line scenario).

More details on `RunConfiguration.DesignMode` is available https://github.com/Microsoft/vstest/issues/344. 