### PR TITLE
Fix and add test for GetRunnerReporter...

### DIFF
--- a/test.xunit.runner.visualstudio.desktop/RunnerReporterTests.cs
+++ b/test.xunit.runner.visualstudio.desktop/RunnerReporterTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Reflection;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Runner.VisualStudio.TestAdapter;
+
+public class RunnerReporterTests
+{
+    public class TestRunnerReporterNotEnabled : IRunnerReporter
+    {
+        string IRunnerReporter.Description => throw new NotImplementedException();
+
+        bool IRunnerReporter.IsEnvironmentallyEnabled => false;
+
+        string IRunnerReporter.RunnerSwitch => throw new NotImplementedException();
+
+        IMessageSink IRunnerReporter.CreateMessageHandler(IRunnerLogger logger) => throw new NotImplementedException();
+    }
+
+    public class TestRunnerReporter : TestRunnerReporterNotEnabled, IRunnerReporter
+    {
+        bool IRunnerReporter.IsEnvironmentallyEnabled => true;
+    }
+
+    [Fact]
+    public void GetRunnerReporter()
+    {
+        var runnerReporter = VsTestRunner.GetRunnerReporter(new[] { Assembly.GetExecutingAssembly().Location });
+
+        Assert.Equal(typeof(TestRunnerReporter).AssemblyQualifiedName, runnerReporter.GetType().AssemblyQualifiedName);
+    }
+}

--- a/test.xunit.runner.visualstudio.desktop/RunnerReporterTests.cs
+++ b/test.xunit.runner.visualstudio.desktop/RunnerReporterTests.cs
@@ -14,7 +14,10 @@ public class RunnerReporterTests
 
         string IRunnerReporter.RunnerSwitch => throw new NotImplementedException();
 
-        IMessageSink IRunnerReporter.CreateMessageHandler(IRunnerLogger logger) => throw new NotImplementedException();
+        IMessageSink IRunnerReporter.CreateMessageHandler(IRunnerLogger logger)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class TestRunnerReporter : TestRunnerReporterNotEnabled, IRunnerReporter

--- a/test.xunit.runner.visualstudio.desktop/packages.config
+++ b/test.xunit.runner.visualstudio.desktop/packages.config
@@ -8,4 +8,5 @@
   <package id="xunit.core" version="2.2.0-rc4-build3529" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.2.0-rc4-build3529" targetFramework="net452" />
   <package id="xunit.extensibility.execution" version="2.2.0-rc4-build3529" targetFramework="net452" />
+  <package id="xunit.runner.utility" version="2.2.0-rc4-build3529" targetFramework="net35" />
 </packages>

--- a/test.xunit.runner.visualstudio.desktop/test.xunit.runner.visualstudio.desktop.csproj
+++ b/test.xunit.runner.visualstudio.desktop/test.xunit.runner.visualstudio.desktop.csproj
@@ -64,6 +64,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="RunnerReporterTests.cs" />
     <Compile Include="RunSettingsHelperTests.cs" />
     <Compile Include="TestCaseFilterTests.cs" />
   </ItemGroup>

--- a/xunit.runner.visualstudio.desktop/VsTestRunner.cs
+++ b/xunit.runner.visualstudio.desktop/VsTestRunner.cs
@@ -507,7 +507,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             return @event;
         }
 
-        static IRunnerReporter GetRunnerReporter(IEnumerable<string> assemblyFileNames)
+        public static IRunnerReporter GetRunnerReporter(IEnumerable<string> assemblyFileNames)
         {
             var reporter = default(IRunnerReporter);
             try
@@ -581,7 +581,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
 #elif NET35
             var result = new List<IRunnerReporter>();
             var runnerPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().GetLocalCodeBase());
-            var runnerReporterInterfaceAssemblyName = typeof(IRunnerReporter).Assembly.GetName();
+            var runnerReporterInterfaceAssemblyFullName = typeof(IRunnerReporter).Assembly.GetName().FullName;
 
             foreach (var dllFile in Directory.GetFiles(runnerPath, "*.dll").Select(f => Path.Combine(runnerPath, f)))
             {
@@ -594,7 +594,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
                     // Calling Assembly.GetTypes can be very expensive, while Assembly.GetReferencedAssemblies
                     // is relatively cheap.  We can avoid loading types for assemblies that couldn't possibly
                     // reference IRunnerReporter.
-                    if (!assembly.GetReferencedAssemblies().Where(name => name == runnerReporterInterfaceAssemblyName).Any())
+                    if (!assembly.GetReferencedAssemblies().Where(name => name.FullName == runnerReporterInterfaceAssemblyFullName).Any())
                         continue;
 
                     types = assembly.GetTypes();


### PR DESCRIPTION
This is a follow-up to #101.  Apologies that I didn't test it better... 🤕

```AssemblyName``` does not override equality, so ```AssemblyName == AssemblyName```
was always ```false```.  Fixing this and adding a test so that mistake doesn't
happen again...