### PR TITLE
Optimizations for test case serialization.

### DIFF
--- a/xunit.runner.visualstudio.desktop/Sinks/VsExecutionSink.cs
+++ b/xunit.runner.visualstudio.desktop/Sinks/VsExecutionSink.cs
@@ -17,19 +17,19 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
         readonly LoggerHelper logger;
         readonly IMessageSinkWithTypes innerSink;
         readonly ITestExecutionRecorder recorder;
-        readonly Dictionary<ITestCase, TestCase> testCases;
+        readonly Dictionary<string, TestCase> testCasesMap;
 
         public VsExecutionSink(IMessageSinkWithTypes innerSink,
                                ITestExecutionRecorder recorder,
                                LoggerHelper logger,
-                               Dictionary<ITestCase, TestCase> testCases,
+                               Dictionary<string, TestCase> testCasesMap,
                                ITestFrameworkExecutionOptions executionOptions,
                                Func<bool> cancelledThunk)
         {
             this.innerSink = innerSink;
             this.recorder = recorder;
             this.logger = logger;
-            this.testCases = testCases;
+            this.testCasesMap = testCasesMap;
             this.executionOptions = executionOptions;
             this.cancelledThunk = cancelledThunk;
 
@@ -63,11 +63,11 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
         TestCase FindTestCase(ITestCase testCase)
         {
             TestCase result;
-            if (testCases.TryGetValue(testCase, out result))
-                return result;
 
-            result = testCases.Where(tc => tc.Key.UniqueID == testCase.UniqueID).Select(kvp => kvp.Value).FirstOrDefault();
-            if (result != null)
+            // PERF: most of the reporting routines below (test case start/end etc.) go through this
+            // comparison. `ITestCase` is a proxy object to appdomain executing the test. Lesser calls to
+            // proxy object is better.
+            if (testCasesMap.TryGetValue(testCase.UniqueID, out result))
                 return result;
 
             logger.LogError(testCase, "Result reported for unknown test case: {0}", testCase.DisplayName);

--- a/xunit.runner.visualstudio.desktop/TestPlatformContext.cs
+++ b/xunit.runner.visualstudio.desktop/TestPlatformContext.cs
@@ -1,0 +1,22 @@
+namespace Xunit.Runner.VisualStudio.TestAdapter
+{
+    /// <summary>
+    /// Provides contextual information on a test run/discovery based on runsettings
+    /// or the invocation (execution, discovery).
+    /// </summary>
+    public struct TestPlatformContext
+    {
+        /// <summary>
+        /// Indicates if VSTestCase object must have FileName or LineNumber information.
+        /// </summary>
+        public bool RequireSourceInformation { get; set; }
+
+        /// <summary>
+        /// Indicates if XunitTestCase needs to be serialized in VSTestCase instance.
+        /// </summary>
+        /// <remarks>XunitTestCase must be serialized if the test case is sent back for xunit to execute.
+        /// E.g. in case of Test Discovery from IDE, user can later select and try to run the test.
+        /// </remarks>
+        public bool RequireXunitTestProperty { get; set; }
+    }
+}

--- a/xunit.runner.visualstudio.desktop/xunit.runner.visualstudio.desktop.csproj
+++ b/xunit.runner.visualstudio.desktop/xunit.runner.visualstudio.desktop.csproj
@@ -67,6 +67,7 @@
     <Compile Include="..\common\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="TestPlatformContext.cs" />
     <Compile Include="Utility\RunSettingsHelper.cs" />
     <Compile Include="Utility\VisualStudioRunnerLogger.cs" />
     <Compile Include="Utility\TestCaseFilter.cs" />

--- a/xunit.runner.visualstudio.dotnetcore/project.json
+++ b/xunit.runner.visualstudio.dotnetcore/project.json
@@ -17,6 +17,7 @@
       "../xunit.runner.visualstudio.desktop/Utility/VisualStudioRunnerLogger.cs",
       "../xunit.runner.visualstudio.desktop/Constants.cs",
       "../xunit.runner.visualstudio.desktop/VsTestRunner.cs",
+      "../xunit.runner.visualstudio.desktop/TestPlatformContext.cs",
       "../common/GlobalAssemblyInfo.cs"
     ],
     "outputName": "xunit.runner.visualstudio.dotnetcore.testadapter",

--- a/xunit.runner.visualstudio.uwp/xunit.runner.visualstudio.uwp.csproj
+++ b/xunit.runner.visualstudio.uwp/xunit.runner.visualstudio.uwp.csproj
@@ -96,6 +96,9 @@
     <Compile Include="..\xunit.runner.visualstudio.desktop\VsTestRunner.cs">
       <Link>VsTestRunner.cs</Link>
     </Compile>
+    <Compile Include="..\xunit.runner.visualstudio.desktop\TestPlatformContext.cs">
+      <Link>TestPlatformContext.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">


### PR DESCRIPTION
Introduced two flags to control SourceInformation and Serialization of xunit test case
as a TestProperty in VSTestCase object. Serialization is enabled for Discovery always and
enabled for Run All or Run Specific test operation only if the test run is triggered from
an IDE.

Moved Discovery (in case of Run All flow) to use the same XunitFrontController as execution
of an assembly. This removed the need for Serialize of XunitTestCase in Discovery[execution]
followed by a Deserialization in actual Execution. A side effect of this is: if multiple assemblies are specified, for each assembly `{discovery, execution}` be sequential instead of `{discovery of all}` followed by `{execution of all}`. This behavior is same as `xunit.console` runner.

Since the ITestCase objects are MarshalByRef, optimized the code in VsExecutionSink to lookup
a VSTestCase based on ITestCase.UniqueId instead of entire ITestCase objects since each access to `ITestCase` has the cost of cross-appdomain proxy call.