### PR TITLE
Removed duplicate ITestCase properties access during ITestCase to VST…

### DIFF
--- a/xunit.runner.visualstudio.desktop/Sinks/VsDiscoverySink.cs
+++ b/xunit.runner.visualstudio.desktop/Sinks/VsDiscoverySink.cs
@@ -39,7 +39,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
         readonly string source;
         readonly bool designMode;
 
-        string lastTestClass;
+        static string lastTestClass;
 
         public VsDiscoverySink(string source,
                                ITestFrameworkDiscoverer discoverer,
@@ -71,26 +71,43 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             discoveryEventSink.Dispose();
         }
 
-        public static TestCase CreateVsTestCase(string source, ITestFrameworkDiscoverer discoverer, ITestCase xunitTestCase, bool forceUniqueName, LoggerHelper logger, bool designMode)
+        public static TestCase CreateVsTestCase(string source, ITestFrameworkDiscoverer discoverer, ITestCase xunitTestCase, bool forceUniqueName, LoggerHelper logger, bool designMode, string testClassName = null, string methodName = null, string uniqueID = null)
         {
             try
             {
+                if (string.IsNullOrEmpty(testClassName))
+                {
+                    testClassName = xunitTestCase.TestMethod.TestClass.Class.Name;
+                }
+
+                if (string.IsNullOrEmpty(methodName))
+                {
+                    methodName = xunitTestCase.TestMethod.Method.Name;
+                }
+
+                if (string.IsNullOrEmpty(uniqueID))
+                {
+                    uniqueID = xunitTestCase.UniqueID;
+                }
+
                 var serializedTestCase = discoverer.Serialize(xunitTestCase);
-                var fqTestMethodName = $"{xunitTestCase.TestMethod.TestClass.Class.Name}.{xunitTestCase.TestMethod.Method.Name}";
+                var fqTestMethodName = $"{testClassName}.{methodName}";
                 var result = new TestCase(fqTestMethodName, uri, source) { DisplayName = Escape(xunitTestCase.DisplayName) };
                 result.SetPropertyValue(VsTestRunner.SerializedTestCaseProperty, serializedTestCase);
-                result.Id = GuidFromString(uri + xunitTestCase.UniqueID);
+                
+                result.Id = GuidFromString(uri + uniqueID);
 
                 if (forceUniqueName)
                 {
-                    ForceUniqueName(result, xunitTestCase.UniqueID);
+                    ForceUniqueName(result, uniqueID);
                 }
 
                 if (addTraitThunk != null)
                 {
-                    foreach (var key in xunitTestCase.Traits.Keys)
+                    Dictionary<string, List<string>> traits = xunitTestCase.Traits;
+                    foreach (var key in traits.Keys)
                     {
-                        foreach (var value in xunitTestCase.Traits[key])
+                        foreach (var value in traits[key])
                             addTraitThunk(result, key, value);
                     }
                 }
@@ -214,7 +231,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
 
             foreach (var testCase in lastTestClassTestCases)
             {
-                var vsTestCase = CreateVsTestCase(source, discoverer, testCase, forceUniqueNames, logger, designMode);
+                var vsTestCase = CreateVsTestCase(source, discoverer, testCase, forceUniqueNames, logger, designMode, lastTestClass);
                 if (vsTestCase != null)
                 {
                     if (discoveryOptions.GetDiagnosticMessagesOrDefault())

--- a/xunit.runner.visualstudio.desktop/Sinks/VsDiscoverySink.cs
+++ b/xunit.runner.visualstudio.desktop/Sinks/VsDiscoverySink.cs
@@ -39,7 +39,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
         readonly string source;
         readonly bool designMode;
 
-        static string lastTestClass;
+        string lastTestClass;
 
         public VsDiscoverySink(string source,
                                ITestFrameworkDiscoverer discoverer,
@@ -204,7 +204,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
             var testCase = args.Message.TestCase;
             var testClass = testCase.TestMethod.TestClass.Class.Name;
             if (lastTestClass != testClass)
-                SendExistingTestCases();
+                SendExistingTestCases(lastTestClass);
 
             lastTestClass = testClass;
             lastTestClassTestCases.Add(testCase);
@@ -215,7 +215,7 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
 
         void HandleDiscoveryCompleteMessage(MessageHandlerArgs<IDiscoveryCompleteMessage> args)
         {
-            SendExistingTestCases();
+            SendExistingTestCases(lastTestClass);
 
             Finished.Set();
 
@@ -225,13 +225,13 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
         bool IMessageSinkWithTypes.OnMessageWithTypes(IMessageSinkMessage message, HashSet<string> messageTypes)
             => discoveryEventSink.OnMessageWithTypes(message, messageTypes);
 
-        private void SendExistingTestCases()
+        private void SendExistingTestCases(string testClassName)
         {
             var forceUniqueNames = lastTestClassTestCases.Count > 1;
 
             foreach (var testCase in lastTestClassTestCases)
             {
-                var vsTestCase = CreateVsTestCase(source, discoverer, testCase, forceUniqueNames, logger, designMode, lastTestClass);
+                var vsTestCase = CreateVsTestCase(source, discoverer, testCase, forceUniqueNames, logger, designMode, testClassName);
                 if (vsTestCase != null)
                 {
                     if (discoveryOptions.GetDiagnosticMessagesOrDefault())

--- a/xunit.runner.visualstudio.desktop/VsTestRunner.cs
+++ b/xunit.runner.visualstudio.desktop/VsTestRunner.cs
@@ -650,10 +650,23 @@ namespace Xunit.Runner.VisualStudio.TestAdapter
 
             public DiscoveredTestCase(string source, ITestFrameworkDiscoverer discoverer, ITestCase testCase, LoggerHelper logger, bool designMode)
             {
-                Name = $"{testCase.TestMethod.TestClass.Class.Name}.{testCase.TestMethod.Method.Name}";
-                TraitNames = testCase.Traits.Keys;
-                VSTestCase = VsDiscoverySink.CreateVsTestCase(source, discoverer, testCase, forceUniqueName: false, logger: logger, designMode: designMode);
+                string testClassName = testCase.TestMethod.TestClass.Class.Name;
+                string methodName = testCase.TestMethod.Method.Name;
+
+                Name = $"{testClassName}.{methodName}";
                 uniqueID = testCase.UniqueID;
+                
+                VSTestCase = VsDiscoverySink.CreateVsTestCase(source,
+                                                              discoverer,
+                                                              testCase, 
+                                                              forceUniqueName: false, 
+                                                              logger: logger, 
+                                                              designMode: designMode, 
+                                                              testClassName: testClassName, 
+                                                              methodName: methodName,
+                                                              uniqueID: uniqueID);
+
+                TraitNames = VSTestCase.Traits.Select(x => x.Name);                
             }
 
             public void ForceUniqueName()


### PR DESCRIPTION
Removed duplicate ITestCase properties access during ITestCase to VSTestCase conversoin. Since ITestCase object is MarshalByRef, any property access goes through transparent proxy and takes time.

For a xunit test project having 25000 plain fact based tests, discovery time for VS2015 Update 3, came down from 5 min 6 sec to 4 min 24 sec on a 8 core 56 GB machine having Win 8.1 64 bit OS.