### PR TITLE
Fix IndexOutOfRange when parsing json string with unicode escaped characters

### DIFF
--- a/src/xunit.runner.visualstudio/Utility/Json.cs
+++ b/src/xunit.runner.visualstudio/Utility/Json.cs
@@ -320,7 +320,7 @@ namespace Xunit
                             }
                             else
                             {
-                                _codePointBuffer[i] = (char)next;
+                                _codePointBuffer.Append((char)next);
                             }
                         }
 


### PR DESCRIPTION
Fixes https://github.com/xunit/xunit/issues/1980