### PR TITLE
Target frameworks not matching

### DIFF
--- a/src/xunit.runner.visualstudio/Utility/RunSettings.cs
+++ b/src/xunit.runner.visualstudio/Utility/RunSettings.cs
@@ -118,12 +118,12 @@ namespace Xunit.Runner.VisualStudio
                    TargetFrameworkVersion.StartsWith("FrameworkCore10", StringComparison.OrdinalIgnoreCase));
 #elif WINDOWS_UAP
             return string.IsNullOrWhiteSpace(TargetFrameworkVersion) || // Short circuit on null since we don't have anything to detect, return true
-                   TargetFrameworkVersion.StartsWith(".NETCore,", StringComparison.OrdinalIgnoreCase) ||
+                   (TargetFrameworkVersion.StartsWith(".NETCore,", StringComparison.OrdinalIgnoreCase) ||
                    TargetFrameworkVersion.StartsWith("Uap,", StringComparison.OrdinalIgnoreCase) ||
                    TargetFrameworkVersion.StartsWith("FrameworkUap10", StringComparison.OrdinalIgnoreCase));
 #else
             if (!string.IsNullOrWhiteSpace(TargetFrameworkVersion) && 
-                TargetFrameworkVersion.StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase) ||
+                (TargetFrameworkVersion.StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase) ||
                 TargetFrameworkVersion.StartsWith("Uap,", StringComparison.OrdinalIgnoreCase) ||
                 TargetFrameworkVersion.StartsWith("FrameworkCore10", StringComparison.OrdinalIgnoreCase) ||
                 TargetFrameworkVersion.StartsWith("FrameworkUap10", StringComparison.OrdinalIgnoreCase)))

--- a/src/xunit.runner.visualstudio/Utility/RunSettings.cs
+++ b/src/xunit.runner.visualstudio/Utility/RunSettings.cs
@@ -113,16 +113,17 @@ namespace Xunit.Runner.VisualStudio
 
 #if NETCOREAPP
             return string.IsNullOrWhiteSpace(TargetFrameworkVersion) ||// Short circuit on null since we don't have anything to detect, return true
-                   (TargetFrameworkVersion.StartsWith(".NETCoreApp,", StringComparison.OrdinalIgnoreCase) ||
+                   (TargetFrameworkVersion.StartsWith("net5", StringComparison.OrdinalIgnoreCase) ||
+                   TargetFrameworkVersion.StartsWith(".NETCoreApp,", StringComparison.OrdinalIgnoreCase) ||
                    TargetFrameworkVersion.StartsWith("FrameworkCore10", StringComparison.OrdinalIgnoreCase));
 #elif WINDOWS_UAP
             return string.IsNullOrWhiteSpace(TargetFrameworkVersion) || // Short circuit on null since we don't have anything to detect, return true
-                   (TargetFrameworkVersion.StartsWith(".NETCore,", StringComparison.OrdinalIgnoreCase) ||
+                   TargetFrameworkVersion.StartsWith(".NETCore,", StringComparison.OrdinalIgnoreCase) ||
                    TargetFrameworkVersion.StartsWith("Uap,", StringComparison.OrdinalIgnoreCase) ||
                    TargetFrameworkVersion.StartsWith("FrameworkUap10", StringComparison.OrdinalIgnoreCase));
 #else
             if (!string.IsNullOrWhiteSpace(TargetFrameworkVersion) && 
-                (TargetFrameworkVersion.StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase) ||
+                TargetFrameworkVersion.StartsWith(".NETCore", StringComparison.OrdinalIgnoreCase) ||
                 TargetFrameworkVersion.StartsWith("Uap,", StringComparison.OrdinalIgnoreCase) ||
                 TargetFrameworkVersion.StartsWith("FrameworkCore10", StringComparison.OrdinalIgnoreCase) ||
                 TargetFrameworkVersion.StartsWith("FrameworkUap10", StringComparison.OrdinalIgnoreCase)))


### PR DESCRIPTION
Nuget.Frameworks started returning DotNetFrameworkName as "net5.0"
which is what vstest will pass down as the target framework name.

There is some guidance how to do that better, but this is a quick fix
to be able to run xUnit tests on net5.0-preview8 and newer, before we
figure out the best way to do this.