### PR TITLE
Fixing a hang in test discovery 

### DIFF
--- a/src/xunit.runner.visualstudio/Sinks/VsDiscoverySink.cs
+++ b/src/xunit.runner.visualstudio/Sinks/VsDiscoverySink.cs
@@ -189,9 +189,16 @@ namespace Xunit.Runner.VisualStudio
 
         void HandleDiscoveryCompleteMessage(MessageHandlerArgs<IDiscoveryCompleteMessage> args)
         {
-            SendExistingTestCases();
-
-            Finished.Set();
+            try
+            {
+                SendExistingTestCases();
+            }
+            finally
+            {
+                // Set test discovery complete despite any potential issues 
+                // with sending test cases over. This would avoid causing test discovery to hang for the entire session.
+                Finished.Set();
+            }
 
             HandleCancellation(args);
         }


### PR DESCRIPTION
Fixing a test discovery hang that was caused because we failed to load a specific version of a dependency while sending tests back to the test platform.

Fixes #291 