### PR TITLE
Update xunit version to 2.4.2-pre.12

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -14,7 +14,6 @@
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)src/signing.snk</AssemblyOriginatorKeyFile>    
-    <XunitVersion>2.4.2-pre.12</XunitVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -13,7 +13,8 @@
     <DebugType>embedded</DebugType>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)src/signing.snk</AssemblyOriginatorKeyFile>        
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)src/signing.snk</AssemblyOriginatorKeyFile>    
+    <XunitVersion>2.4.2-pre.12</XunitVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/xunit.runner.visualstudio/xunit.runner.visualstudio.csproj
+++ b/src/xunit.runner.visualstudio/xunit.runner.visualstudio.csproj
@@ -17,6 +17,7 @@
     <TargetPlatformVersion Condition=" '$(TargetFramework)' == 'uap10.0.16299' ">10.0.19041.0</TargetPlatformVersion>
     <!-- Set the PackageId explicitly as our different AssemblyNames will cause restore errors otherwise -->
     <PackageId>xunit.runner.visualstudio</PackageId>
+    <XunitVersion>2.4.2-pre.12</XunitVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/xunit.runner.visualstudio/xunit.runner.visualstudio.csproj
+++ b/src/xunit.runner.visualstudio/xunit.runner.visualstudio.csproj
@@ -12,7 +12,6 @@
 
     <DevelopmentDependency>true</DevelopmentDependency>
     <BuildOutputTargetFolder>build</BuildOutputTargetFolder>
-    <XunitVersion>2.4.2-pre.12</XunitVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>$(NoWarn)1701;1702;NU5105</NoWarn>
     <TargetPlatformVersion Condition=" '$(TargetFramework)' == 'uap10.0.16299' ">10.0.19041.0</TargetPlatformVersion>

--- a/src/xunit.runner.visualstudio/xunit.runner.visualstudio.csproj
+++ b/src/xunit.runner.visualstudio/xunit.runner.visualstudio.csproj
@@ -12,7 +12,7 @@
 
     <DevelopmentDependency>true</DevelopmentDependency>
     <BuildOutputTargetFolder>build</BuildOutputTargetFolder>
-    <XunitVersion>2.4.1</XunitVersion>
+    <XunitVersion>2.4.2-pre.12</XunitVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>$(NoWarn)1701;1702;NU5105</NoWarn>
     <TargetPlatformVersion Condition=" '$(TargetFramework)' == 'uap10.0.16299' ">10.0.19041.0</TargetPlatformVersion>

--- a/test/test.harness.uwp/test.harness.uwp.csproj
+++ b/test/test.harness.uwp/test.harness.uwp.csproj
@@ -111,7 +111,7 @@
     <!-- I don't know where these are coming from, but older 4.0 versions are being included and causing downgrades -->
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/test/test.harness/test.harness.csproj
+++ b/test/test.harness/test.harness.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/test.harness/test.harness.csproj
+++ b/test/test.harness/test.harness.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/test.testcasefilter/test.testcasefilter.csproj
+++ b/test/test.testcasefilter/test.testcasefilter.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
   </ItemGroup>
 
 </Project>

--- a/test/test.testcasefilter/test.testcasefilter.csproj
+++ b/test/test.testcasefilter/test.testcasefilter.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/test.xunit.runner.visualstudio/test.xunit.runner.visualstudio.csproj
+++ b/test/test.xunit.runner.visualstudio/test.xunit.runner.visualstudio.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.reporters" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
+    <PackageReference Include="xunit.runner.reporters" Version="2.4.2-pre.12" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 

--- a/test/test.xunit.runner.visualstudio/test.xunit.runner.visualstudio.csproj
+++ b/test/test.xunit.runner.visualstudio/test.xunit.runner.visualstudio.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.reporters" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.reporters" Version="$(XunitVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Depend on the latest released xunit packages as their assembly versions got updated to 2.4.2 instead of 2.4.1.

@clairernovotny you already updated the package version in the version.json file this February. Do we need another update or are your changes sufficient? And is the produced package automatically published to nuget.org when merged into main?

Last question, do we want to update the packages with a prerelease label same as the other xunit package or is stable fine?