### PR TITLE
Downgrade xunit.runner.vs to net462

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ To open an issue for this project, please visit the [core xUnit.net project issu
 
 ## Debugging
 
-Debugging the VS Adapter is tricky. There are two ways to do it depending on whether you want to do it under `net472` or `netcoreapp3.1`. In all cases, you'll currently need to build your own test adapter NuGet package using `build.ps1`, `build.ps1 Packages` first to ensure you have local symbols. The symbols are not in the public package. It's helpful to add it to a local `\packages` directory and then use an entry like `<add key="Local Packages" value=".\packages" />` in your `NuGet.config` file to point to it. Don't forget to eventually delete it from your global profile `.nuget\packages\xunit...` when you're done.
+Debugging the VS Adapter is tricky. There are two ways to do it depending on whether you want to do it under `net462` or `netcoreapp3.1`. In all cases, you'll currently need to build your own test adapter NuGet package using `build.ps1`, `build.ps1 Packages` first to ensure you have local symbols. The symbols are not in the public package. It's helpful to add it to a local `\packages` directory and then use an entry like `<add key="Local Packages" value=".\packages" />` in your `NuGet.config` file to point to it. Don't forget to eventually delete it from your global profile `.nuget\packages\xunit...` when you're done.
 
-### `net472`
+### `net462`
 Easiest thing to do is add a `launchSettings.json` file that adds the `vstest.console.exe` as a startup project and point it to an xunit dll. Something like the following (use `/listtests` if you just want to debug the discovery portion):
 
 ```json
@@ -16,7 +16,7 @@ Easiest thing to do is add a `launchSettings.json` file that adds the `vstest.co
   "profiles": {
     "vstest console": {
       "executablePath": "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe",
-      "commandLineArgs": ".\\bin\\Debug\\net472\\Tests.System.Reactive.dll /TestAdapterPath:.\\bin\\Debug\\net472 /listtests",
+      "commandLineArgs": ".\\bin\\Debug\\net462\\Tests.System.Reactive.dll /TestAdapterPath:.\\bin\\Debug\\net462 /listtests",
       "workingDirectory": "C:\\dev\\RxNET\\Rx.NET\\Source\\Tests.System.Reactive\\"
     }
   }

--- a/src/xunit.runner.visualstudio/Constants.cs
+++ b/src/xunit.runner.visualstudio/Constants.cs
@@ -2,7 +2,7 @@
 {
     public static class Constants
     {
-#if NET472
+#if NETFRAMEWORK
         public const string ExecutorUri = "executor://xunit/VsTestRunner2/net";
 #elif WINDOWS_UAP
         public const string ExecutorUri = "executor://xunit/VsTestRunner2/uap";

--- a/src/xunit.runner.visualstudio/xunit.runner.visualstudio.csproj
+++ b/src/xunit.runner.visualstudio/xunit.runner.visualstudio.csproj
@@ -17,7 +17,7 @@
     <TargetPlatformVersion Condition=" '$(TargetFramework)' == 'uap10.0.16299' ">10.0.19041.0</TargetPlatformVersion>
     <!-- Set the PackageId explicitly as our different AssemblyNames will cause restore errors otherwise -->
     <PackageId>xunit.runner.visualstudio</PackageId>
-    <XunitVersion>2.4.2-pre.12</XunitVersion>
+    <XunitVersion>2.4.2-pre.22</XunitVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/src/xunit.runner.visualstudio/xunit.runner.visualstudio.csproj
+++ b/src/xunit.runner.visualstudio/xunit.runner.visualstudio.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>xUnit.net Runner for Visual Studio ($(TargetFramework))</AssemblyTitle>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Xunit.Runner.VisualStudio</RootNamespace>
-    <TargetFrameworks>net472;netcoreapp3.1;uap10.0.16299</TargetFrameworks>    
+    <TargetFrameworks>net462;netcoreapp3.1;uap10.0.16299</TargetFrameworks>    
     <WarningsAsErrors>true</WarningsAsErrors>
     <Description>Visual Studio 2019 16.8+ Test Explorer runner for the xUnit.net framework. Capable of running xUnit.net v1.9.2 and v2.0+ tests. Supports .NET 4.7.2 or later, .NET Core 3.1 or later, and Universal Windows 10.0.16299 or later.</Description>
 
@@ -20,7 +20,7 @@
     <XunitVersion>2.4.2-pre.12</XunitVersion>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <AssemblyName>xunit.runner.visualstudio.testadapter</AssemblyName>    
     <DefineConstants>$(DefineConstants);NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
@@ -42,18 +42,18 @@
 
   <ItemGroup Label="Package">
     <None Include="build\xunit.runner.visualstudio.desktop.props" 
-          PackagePath="build\net472\xunit.runner.visualstudio.props" 
+          PackagePath="build\net462\xunit.runner.visualstudio.props" 
           Pack="true" />
     <None Include="$(NuGetPackageRoot)xunit.runner.reporters\$(XunitVersion)\lib\net452\*.dll" 
-          PackagePath="build\net472" 
+          PackagePath="build\net462" 
           Pack="true" 
           Visible="false" />
     <None Include="$(NuGetPackageRoot)xunit.runner.utility\$(XunitVersion)\lib\net452\*.dll" 
-          PackagePath="build\net472" 
+          PackagePath="build\net462" 
           Pack="true" 
           Visible="false" />
     <None Include="$(NuGetPackageRoot)xunit.abstractions\2.0.3\lib\netstandard1.0\*.dll" 
-          PackagePath="build\net472" 
+          PackagePath="build\net462" 
           Pack="true" 
           Visible="false" />
 
@@ -81,7 +81,7 @@
           Pack="true" />
 
     <None Include="build\_._" 
-          PackagePath="lib\net472" 
+          PackagePath="lib\net462" 
           Pack="true" />
     <None Include="build\_._" 
           PackagePath="lib\netcoreapp3.1" 

--- a/test/test.harness.uwp/test.harness.uwp.csproj
+++ b/test/test.harness.uwp/test.harness.uwp.csproj
@@ -111,7 +111,7 @@
     <!-- I don't know where these are coming from, but older 4.0 versions are being included and causing downgrades -->
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.22" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/test/test.harness/test.harness.csproj
+++ b/test/test.harness/test.harness.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/test.harness/test.harness.csproj
+++ b/test/test.harness/test.harness.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test.testcasefilter/test.testcasefilter.csproj
+++ b/test/test.testcasefilter/test.testcasefilter.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.22" />
   </ItemGroup>
 
 </Project>

--- a/test/test.testcasefilter/test.testcasefilter.csproj
+++ b/test/test.testcasefilter/test.testcasefilter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test.xunit.runner.visualstudio/test.xunit.runner.visualstudio.csproj
+++ b/test/test.xunit.runner.visualstudio/test.xunit.runner.visualstudio.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
-    <PackageReference Include="xunit.runner.reporters" Version="2.4.2-pre.12" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.22" />
+    <PackageReference Include="xunit.runner.reporters" Version="2.4.2-pre.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 

--- a/test/test.xunit.runner.visualstudio/test.xunit.runner.visualstudio.csproj
+++ b/test/test.xunit.runner.visualstudio/test.xunit.runner.visualstudio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.10.0" />
   </ItemGroup>
 


### PR DESCRIPTION
See discussion in https://github.com/xunit/visualstudio.xunit/pull/304#issuecomment-1117690251 for context. .NETFramework 4.6.2 and above is still in support and support shouldn't be dropped for it from the package.