### PR TITLE
Fix test discovery for FullyQualifiedName and DisplayName

### DIFF
--- a/src/xunit.runner.visualstudio/Utility/TestCaseFilter.cs
+++ b/src/xunit.runner.visualstudio/Utility/TestCaseFilter.cs
@@ -63,12 +63,14 @@ public class TestCaseFilter
 		TestCase testCase,
 		string name)
 	{
-		// Getting traits for current test case for pre-check
-		var traitsKeys = new HashSet<string>();
-		foreach (var traits in GetTraits(testCase)) traitsKeys.Add(traits.Key);
+		// Special case for "FullyQualifiedName" and "DisplayName"
+		if (string.Equals(name, FullyQualifiedNameString, StringComparison.OrdinalIgnoreCase))
+			return testCase.FullyQualifiedName;
+		if (string.Equals(name, DisplayNameString, StringComparison.OrdinalIgnoreCase))
+			return testCase.DisplayName;
 
 		// Traits filtering
-		if ((isDiscovery && traitsKeys.Contains(name)) || knownTraits.Contains(name))
+		if (isDiscovery || knownTraits.Contains(name))
 		{
 			var result = new List<string>();
 
@@ -78,14 +80,6 @@ public class TestCaseFilter
 
 			if (result.Count > 0)
 				return result.ToArray();
-		}
-		else
-		{
-			// Handle the displayName and fullyQualifierNames independently
-			if (string.Equals(name, FullyQualifiedNameString, StringComparison.OrdinalIgnoreCase))
-				return testCase.FullyQualifiedName;
-			if (string.Equals(name, DisplayNameString, StringComparison.OrdinalIgnoreCase))
-				return testCase.DisplayName;
 		}
 
 		return null;

--- a/src/xunit.runner.visualstudio/Utility/TestCaseFilter.cs
+++ b/src/xunit.runner.visualstudio/Utility/TestCaseFilter.cs
@@ -63,8 +63,12 @@ public class TestCaseFilter
 		TestCase testCase,
 		string name)
 	{
+		// Getting traits for current test case for pre-check
+		var traitsKeys = new HashSet<string>();
+		foreach (var traits in GetTraits(testCase)) traitsKeys.Add(traits.Key);
+
 		// Traits filtering
-		if (isDiscovery || knownTraits.Contains(name))
+		if ((isDiscovery && traitsKeys.Contains(name)) || knownTraits.Contains(name))
 		{
 			var result = new List<string>();
 

--- a/test/test.xunit.runner.visualstudio/TestCaseFilterTests.cs
+++ b/test/test.xunit.runner.visualstudio/TestCaseFilterTests.cs
@@ -12,7 +12,7 @@ using Constants = Xunit.Runner.VisualStudio.Constants;
 
 public class TestCaseFilterTests
 {
-	readonly HashSet<string> dummyKnownTraits = new HashSet<string>(new string[3] { "Platform", "Product", "Priority" });
+	readonly HashSet<string> dummyKnownTraits = new() { "Platform", "Product", "Priority" };
 
 	static IReadOnlyList<TestCase> GetDummyTestCases()
 	{

--- a/test/test.xunit.runner.visualstudio/TestCaseFilterTests.cs
+++ b/test/test.xunit.runner.visualstudio/TestCaseFilterTests.cs
@@ -12,7 +12,7 @@ using Constants = Xunit.Runner.VisualStudio.Constants;
 
 public class TestCaseFilterTests
 {
-	readonly HashSet<string> dummyKnownTraits = new HashSet<string>(new string[2] { "Platform", "Product" });
+	readonly HashSet<string> dummyKnownTraits = new HashSet<string>(new string[3] { "Platform", "Product", "Priority" });
 
 	static IReadOnlyList<TestCase> GetDummyTestCases()
 	{
@@ -22,6 +22,15 @@ public class TestCaseFilterTests
 			testCaseList.Add(new TestCase("Test" + i, new Uri(Constants.ExecutorUri), "DummyTestSource"));
 
 		return testCaseList;
+	}
+
+	static TestCase GetDummyTestCaseWithTraits()
+	{
+		return new TestCase("propertyProviderTestFullyName", new Uri(Constants.ExecutorUri), "DummyTestSource")
+		{
+			DisplayName = "propertyProviderTestDisplayName",
+			Traits = { new Trait("Priority", "0"), new Trait("Category", "unit_0"), new Trait("Category", "unit_1") }
+		};
 	}
 
 	static LoggerHelper GetLoggerHelper(IMessageLogger messageLogger = null)
@@ -79,5 +88,95 @@ public class TestCaseFilterTests
 			arg => Assert.Equal(TestMessageLevel.Warning, arg),
 			arg => Assert.EndsWith("dummyTestAssembly: Exception filtering tests: Hello from the exception", (string)arg)
 		);
+	}
+
+	[Fact]
+	public void TestCaseFilter_TestPropertyProviderWithDiscoveryContextForTraits()
+	{
+		var dummyTestCase = GetDummyTestCaseWithTraits();
+		var context = Substitute.For<IDiscoveryContext>();
+		var filter = new TestCaseFilter(context, GetLoggerHelper());
+		var targetTraitKey = "Category";
+
+		var propertyResult = filter.PropertyProvider(dummyTestCase, targetTraitKey);
+
+		Assert.NotNull(propertyResult);
+		Assert.IsType<string[]>(propertyResult);
+		Assert.Equal(dummyTestCase.Traits.Where(t => t.Name.Equals(targetTraitKey, StringComparison.OrdinalIgnoreCase)).Count(), ((string[])propertyResult).Count());
+	}
+
+	[Fact]
+	public void TestCaseFilter_TestPropertyProviderWithDiscoveryContextForFullyQualifiedName()
+	{
+		var dummyTestCase = GetDummyTestCaseWithTraits();
+		var context = Substitute.For<IDiscoveryContext>();
+		var filter = new TestCaseFilter(context, GetLoggerHelper());
+		var targetName = "FullyQualifiedName";
+
+		var propertyResult = filter.PropertyProvider(dummyTestCase, targetName);
+
+		Assert.NotNull(propertyResult);
+		Assert.IsType<string>(propertyResult);
+		Assert.Equal("propertyProviderTestFullyName", propertyResult);
+	}
+
+	[Fact]
+	public void TestCaseFilter_TestPropertyProviderWithDiscoveryContextForDisplayName()
+	{
+		var dummyTestCase = GetDummyTestCaseWithTraits();
+		var context = Substitute.For<IDiscoveryContext>();
+		var filter = new TestCaseFilter(context, GetLoggerHelper());
+		var targetName = "DisplayName";
+
+		var propertyResult = filter.PropertyProvider(dummyTestCase, targetName);
+
+		Assert.NotNull(propertyResult);
+		Assert.IsType<string>(propertyResult);
+		Assert.Equal("propertyProviderTestDisplayName", propertyResult);
+	}
+
+	[Fact]
+	public void TestCaseFilter_TestPropertyProviderWithRunContextForTraits()
+	{
+		var dummyTestCase = GetDummyTestCaseWithTraits();
+		var context = Substitute.For<IRunContext>();
+		var filter = new TestCaseFilter(context, GetLoggerHelper(), "dummyTestAssembly", dummyKnownTraits);
+		var targetTraitKey = "Priority";
+
+		var propertyResult = filter.PropertyProvider(dummyTestCase, targetTraitKey);
+
+		Assert.NotNull(propertyResult);
+		Assert.IsType<string[]>(propertyResult);
+		Assert.Equal(dummyTestCase.Traits.Where(t => t.Name.Equals(targetTraitKey, StringComparison.OrdinalIgnoreCase)).Count(), ((string[])propertyResult).Count());
+	}
+
+	[Fact]
+	public void TestCaseFilter_TestPropertyProviderWithRunContextForFullyQualifiedName()
+	{
+		var dummyTestCase = GetDummyTestCaseWithTraits();
+		var context = Substitute.For<IRunContext>();
+		var filter = new TestCaseFilter(context, GetLoggerHelper(), "dummyTestAssembly", dummyKnownTraits);
+		var targetName = "FullyQualifiedName";
+
+		var propertyResult = filter.PropertyProvider(dummyTestCase, targetName);
+
+		Assert.NotNull(propertyResult);
+		Assert.IsType<string>(propertyResult);
+		Assert.Equal("propertyProviderTestFullyName", propertyResult);
+	}
+
+	[Fact]
+	public void TestCaseFilter_TestPropertyProviderWithRunContextForDisplayName()
+	{
+		var dummyTestCase = GetDummyTestCaseWithTraits();
+		var context = Substitute.For<IRunContext>();
+		var filter = new TestCaseFilter(context, GetLoggerHelper(), "dummyTestAssembly", dummyKnownTraits);
+		var targetName = "DisplayName";
+
+		var propertyResult = filter.PropertyProvider(dummyTestCase, targetName);
+
+		Assert.NotNull(propertyResult);
+		Assert.IsType<string>(propertyResult);
+		Assert.Equal("propertyProviderTestDisplayName", propertyResult);
 	}
 }


### PR DESCRIPTION
This PR is to fix test discovery for FullyQualifiedName and DisplayName filter. 
As in #370 , issue details has been brought out and these are code changes that I propose.

Here is the screenshot showing that it works. Ignoring the log that starts with [xUnit , it will only print the full name, which is Class plus method, on the screen.
![image](https://github.com/xunit/visualstudio.xunit/assets/123312912/d5151172-ed0e-4182-a8de-adbe98bea526)
UT for the method that I made changes is written as well.

@bradwilson @nohwnd Would you please review it and feel free to comment if there is anything needed to fix? Thanks!