### PR TITLE
Fix concurrency bug in AssemblyHelper

### DIFF
--- a/src/xunit.runner.visualstudio/Utility/AssemblyResolution/AssemblyHelper_Desktop.cs
+++ b/src/xunit.runner.visualstudio/Utility/AssemblyResolution/AssemblyHelper_Desktop.cs
@@ -1,6 +1,7 @@
 #if NETFRAMEWORK
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -19,7 +20,7 @@ class AssemblyHelper : LongLivedMarshalByRefObject, IDisposable
 
 	readonly string directory;
 	readonly IMessageSink? internalDiagnosticsMessageSink;
-	readonly Dictionary<string, Assembly?> lookupCache = new();
+	readonly ConcurrentDictionary<string, Assembly?> lookupCache = new();
 
 	/// <summary>
 	/// Constructs an instance using the given <paramref name="directory"/> for resolution.

--- a/src/xunit.runner.visualstudio/Utility/AssemblyResolution/AssemblyHelper_Desktop.cs
+++ b/src/xunit.runner.visualstudio/Utility/AssemblyResolution/AssemblyHelper_Desktop.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Xunit.Abstractions;


### PR DESCRIPTION
AssemblyResolve event could be triggered from multiple threads, so using a normal Dictionary may cause infinite loop when TryGetValue is being called and another thread has corrupted its internal state, replace it with ConcurrentDictionary.

